### PR TITLE
exporting download_url with gen. xml; fixes #104

### DIFF
--- a/app/api/views.py
+++ b/app/api/views.py
@@ -326,12 +326,6 @@ def get_single_xml_metadata(_oid):
     _enclose_word = lambda k: {'word': k}
     _enclose_words = lambda words: map(_enclose_word, words)
 
-    # def _enclose_word(word):
-    #         return {'word': word}
-
-    # def _enclose_words(words):
-    #     return [_enclose_word(word) for word in words]
-
     json_rec['thematic_keywords'] = _enclose_words(
                                         json_rec['thematic_keywords'])
 
@@ -344,6 +338,9 @@ def get_single_xml_metadata(_oid):
     _enclose_url = lambda url: {'url': url}
 
     json_rec['online'] = map(_enclose_url, json_rec['online'])
+
+    json_rec['download_url'] = \
+        app.config['ATTACHMENT_DOWNLOAD_BASE_URL'] + str(record.id)
 
     xml_str = dicttoxml(dict(record=json_rec))  # , attr_type=False)
 

--- a/config.py
+++ b/config.py
@@ -15,8 +15,12 @@ class Config:
     PREPROD_DIRECTORY = (os.environ.get('MDEDIT_PREPROD_DIRECTORY') or
                          'local-preprod-directory')
 
+    UPLOADS_DEFAULT_DEST = 'app/static/test-uploads'
+
     if not os.path.exists(PREPROD_DIRECTORY):
         os.makedirs(PREPROD_DIRECTORY)
+
+    ATTACHMENT_DOWNLOAD_BASE_URL = 'http://example.com/downloads?uuid='
 
     @staticmethod
     def init_app(app):
@@ -26,8 +30,6 @@ class Config:
 class DevelopmentConfig(Config):
     DEBUG = True
 
-    UPLOADS_DEFAULT_DEST = 'app/static/uploads'
-
 
 class TestingConfig(Config):
     TESTING = True
@@ -35,14 +37,14 @@ class TestingConfig(Config):
     MONGODB_SETTINGS = {'db': 'mdedit_test'}
     PREPROD_DIRECTORY = os.getcwd() + '/mdedit_preprod_test'
 
-    UPLOADS_DEFAULT_DEST = 'app/static/test-uploads'
-
     if not os.path.exists(PREPROD_DIRECTORY):
         os.makedirs(PREPROD_DIRECTORY)
 
 
 class ProductionConfig(Config):
-    pass
+
+    ATTACHMENT_DOWNLOAD_BASE_URL = \
+        'https://www.northwestknowledge.net/data/download.php?uuid='
 
 
 config = {

--- a/xslt/XSLT_for_mdedit.xsl
+++ b/xslt/XSLT_for_mdedit.xsl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0"
+o<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0"
     xmlns:gco="http://www.isotc211.org/2005/gco" xmlns:gmd="http://www.isotc211.org/2005/gmd"
     xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:gts="http://www.isotc211.org/2005/gts"
     xmlns:gmi="http://www.isotc211.org/2005/gmi" xmlns:gmx="http://www.isotc211.org/2005/gmx"
@@ -765,20 +765,18 @@
                                             </gmd:CI_OnlineResource>
                                         </gmd:onLine>
                                         </xsl:for-each>
-                                        <xsl:for-each select="/root/record/attachments/item">
-                                            <gmd:onLine>
-                                                <gmd:CI_OnlineResource>
-                                                    <gmd:linkage>
-                                                        <gmd:URL>
-                                                            <xsl:value-of select="url"/>
-                                                        </gmd:URL>
-                                                    </gmd:linkage>
-                                                    <gmd:function>
-                                                        <gmd:CI_OnLineFunctionCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_OnLineFunctionCode" codeListValue="download">download</gmd:CI_OnLineFunctionCode>
-                                                    </gmd:function>
-                                                </gmd:CI_OnlineResource>
-                                            </gmd:onLine>
-                                        </xsl:for-each>
+                                        <gmd:onLine>
+                                            <gmd:CI_OnlineResource>
+                                                <gmd:linkage>
+                                                    <gmd:URL>
+                                                        <xsl:value-of select="/root/record/download_url"/>
+                                                    </gmd:URL>
+                                                </gmd:linkage>
+                                                <gmd:function>
+                                                    <gmd:CI_OnLineFunctionCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_OnLineFunctionCode" codeListValue="download">download</gmd:CI_OnLineFunctionCode>
+                                                </gmd:function>
+                                            </gmd:CI_OnlineResource>
+                                        </gmd:onLine>
                                     </gmd:MD_DigitalTransferOptions>
                                 </gmd:distributorTransferOptions>
                             </gmd:MD_Distributor>

--- a/xslt/XSLT_for_mdedit.xsl
+++ b/xslt/XSLT_for_mdedit.xsl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-o<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0"
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0"
     xmlns:gco="http://www.isotc211.org/2005/gco" xmlns:gmd="http://www.isotc211.org/2005/gmd"
     xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:gts="http://www.isotc211.org/2005/gts"
     xmlns:gmi="http://www.isotc211.org/2005/gmi" xmlns:gmx="http://www.isotc211.org/2005/gmx"

--- a/xslt/XSLT_for_mdedit_ESRI.xsl
+++ b/xslt/XSLT_for_mdedit_ESRI.xsl
@@ -335,6 +335,9 @@
                         <linkage><xsl:value-of select="url"/></linkage>
                     </onLineSrc>
                     </xsl:for-each>
+                    <onlineSrc>
+                        <linkage><xsl:value-of select="/root/record/download_url"/></linkage>
+                    </onlineSrc>
                 </distTranOps>
             </distInfo>
             <mdFileID>nkn:<xsl:value-of select="/root/record/_id/key"/></mdFileID>

--- a/xslt/XSLT_for_mdedit_ESRIISO.xsl
+++ b/xslt/XSLT_for_mdedit_ESRIISO.xsl
@@ -765,6 +765,18 @@
                                             </gmd:CI_OnlineResource>
                                         </gmd:onLine>
                                         </xsl:for-each>
+                                        <gmd:onLine>
+                                            <gmd:CI_OnlineResource>
+                                                <gmd:linkage>
+                                                    <gmd:URL>
+                                                        <xsl:value-of select="/root/record/download_url"/>
+                                                    </gmd:URL>
+                                                </gmd:linkage>
+                                                <gmd:function>
+                                                    <gmd:CI_OnLineFunctionCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_OnLineFunctionCode" codeListValue="download">download</gmd:CI_OnLineFunctionCode>
+                                                </gmd:function>
+                                            </gmd:CI_OnlineResource>
+                                        </gmd:onLine>
                                     </gmd:MD_DigitalTransferOptions>
                                 </gmd:distributorTransferOptions>
                             </gmd:MD_Distributor>

--- a/xslt/XSLT_for_mdedit_dublineCore.xsl
+++ b/xslt/XSLT_for_mdedit_dublineCore.xsl
@@ -25,11 +25,9 @@
                         <xsl:value-of select="url"/>
                     </dct:references>
                 </xsl:for-each>
-                <xsl:for-each select="/root/record/attachments/item">
                     <dct:references>
-                        <xsl:value-of select="url"/>
+                        <xsl:value-of select="/root/record/download_url"/>
                     </dct:references>
-                </xsl:for-each>
                 <xsl:for-each select="/root/record/citation/item">
                     <dc:creator><xsl:value-of select="name"/>, <xsl:value-of select="org"/>,
                             <xsl:value-of select="email"/>, <xsl:value-of select="address"/>,


### PR DESCRIPTION
If you are running in development (the default if you haven't set `FLASKCONFIG` environment variable) the download_url will be the fake `http://example.com/downloads?uuid={UUID}`.

Run it in production to see what it will look like in production by executing

```
FLASKCONFIG=production
export FLASKCONFIG
```

in a terminal.