### PR TITLE
attachments with UUID to the upload service and metadata.xml pushed to upload service on publish

### DIFF
--- a/app/api/views.py
+++ b/app/api/views.py
@@ -194,16 +194,24 @@ def publish_metadata_record(_oid):
 
         # print app.config
         save_dir = app.config['PREPROD_DIRECTORY']
-
         save_path = os.path.join(save_dir,
                              str_id,
-                             str_id + '.xml')
+                             'metadata.xml')
 
         if not os.path.exists(os.path.dirname(save_path)):
             os.mkdir(os.path.dirname(save_path))
 
         with open(save_path, 'w+') as f:
             f.write(iso)
+        if app.config['PRODUCTION']:
+
+            nkn_upload_url = \
+               "https://nknportal-dev.nkn.uidaho.edu" + \
+               "/portal/simpleUpload/upload.php"
+
+            rep = requests.post(nkn_upload_url,
+                                {'uuid': str_id},
+                                files={'uploadedfile': open(save_path, 'rb')})
 
         if 'localhost' not in request.base_url:
             gptInsert.gptInsertRecord(iso, record.title)
@@ -220,13 +228,24 @@ def publish_metadata_record(_oid):
 
         save_path = os.path.join(save_dir,
                              str_id,
-                             str_id + '.xml')
+                             'metadata.xml')
 
         if not os.path.exists(os.path.dirname(save_path)):
             os.mkdir(os.path.dirname(save_path))
 
         with open(save_path, 'w+') as f:
             f.write(dc)
+            f.close()
+
+        if app.config['PRODUCTION']:
+
+            nkn_upload_url = \
+               "https://nknportal-dev.nkn.uidaho.edu" + \
+               "/portal/simpleUpload/upload.php"
+
+            rep = requests.post(nkn_upload_url,
+                                {'uuid': str_id},
+                                files={'uploadedfile': open(save_path, 'rb')})
 
         if 'localhost' not in request.base_url:
             gptInsert.gptInsertRecord(dc, record.title)

--- a/app/api/views.py
+++ b/app/api/views.py
@@ -436,13 +436,14 @@ def upload():
 
         try:
             f = request.files['uploadedfile']
-            uploadedfiles.save(f)
+            uuid = request.form['uuid']
+            uploadedfiles.save(f, folder=uuid)
 
             ret = {
                 "message": "Upload successful",
                 "source": f.filename,
                 "url": 'http://localhost:4000/static/uploads/uploadedfiles/' +
-                       f.filename
+                       uuid + '/' + f.filename
             }
             return jsonify(ret)
 

--- a/config.py
+++ b/config.py
@@ -15,7 +15,7 @@ class Config:
     PREPROD_DIRECTORY = (os.environ.get('MDEDIT_PREPROD_DIRECTORY') or
                          'local-preprod-directory')
 
-    UPLOADS_DEFAULT_DEST = 'app/static/test-uploads'
+    UPLOADS_DEFAULT_DEST = 'app/static/uploads'
 
     if not os.path.exists(PREPROD_DIRECTORY):
         os.makedirs(PREPROD_DIRECTORY)
@@ -36,6 +36,8 @@ class TestingConfig(Config):
 
     MONGODB_SETTINGS = {'db': 'mdedit_test'}
     PREPROD_DIRECTORY = os.getcwd() + '/mdedit_preprod_test'
+
+    UPLOADS_DEFAULT_DEST = 'app/static/test-uploads'
 
     if not os.path.exists(PREPROD_DIRECTORY):
         os.makedirs(PREPROD_DIRECTORY)

--- a/config.py
+++ b/config.py
@@ -9,6 +9,7 @@ PREPROD_DIRECTORY = (os.environ.get('MDEDIT_PREPROD_DIRECTORY') or
                          'local-preprod-directory')
 
 class Config:
+    PRODUCTION = False
 
     MONGODB_SETTINGS = {'db': 'mdedit'}
 
@@ -44,6 +45,7 @@ class TestingConfig(Config):
 
 
 class ProductionConfig(Config):
+    PRODUCTION = True
 
     ATTACHMENT_DOWNLOAD_BASE_URL = \
         'https://www.northwestknowledge.net/data/download.php?uuid='

--- a/frontend/js/controllers.js
+++ b/frontend/js/controllers.js
@@ -370,24 +370,22 @@ metadataEditorApp.controller('BaseController',
 
             var file = $scope.attachmentInfo.newAttachment;
 
-            // $log.log($scope);
+            // in order to attach files we need an identifier
+            var recordId;
+            if ($scope.currentRecord.hasOwnProperty('_id'))
+            {
+                recordId = $scope.currentRecord._id.$oid;
+            }
+            else
+            {
+                $scope.submitDraftRecord();
+                recordId = $scope.currentRecord._id.$oid;
+            }
 
-            $log.log(file);
-
-            AttachmentService.uploadFile(file)
+            // if upload is successful, sync upload with the metadata
+            AttachmentService.uploadFile(file, recordId)
                 .success(function (data) {
                     var url = data.url;
-                    var recordId;
-                    if ($scope.currentRecord.hasOwnProperty('_id'))
-                    {
-                        recordId = $scope.currentRecord._id.$oid;
-                    }
-                    else
-                    {
-                        $scope.submitDraftRecord();
-                        recordId = $scope.currentRecord._id.$oid;
-                    }
-
                     AttachmentService.attachFile(url, recordId)
                         .success(function (attachData) {
 

--- a/frontend/js/services.js
+++ b/frontend/js/services.js
@@ -537,13 +537,12 @@ metadataEditorApp
         attachBaseRoute = '//' + hostname + '/api/metadata/';
     }
 
-    var uploadFile = function(file) {
+    var uploadFile = function(file, recordId) {
 
         var fd = new FormData();
 
         fd.append('uploadedfile', file);
-
-        $log.log('appended, now on to posting...');
+        fd.append('uuid', recordId);
 
         return $http.post(uploadUrl, fd, {
             // transformRequest: angular.identity,

--- a/frontend/js/services.js
+++ b/frontend/js/services.js
@@ -517,17 +517,17 @@ metadataEditorApp
         comment out following block and uncomment the next block to
         test with NKN resources
     */
-    var uploadUrl;
-    if (hostname === 'localhost:4000') {
-        uploadUrl = 'http://localhost:4000/api/upload';
-    }
-    else {
-        uploadUrl =
-            'https://nknportal-dev.nkn.uidaho.edu/portal/simpleUpload/upload.php';
-    }
+    //var uploadUrl;
+    //if (hostname === 'localhost:4000') {
+        //uploadUrl = 'http://localhost:4000/api/upload';
+    //}
+    //else {
+        //uploadUrl =
+            //'https://nknportal-dev.nkn.uidaho.edu/portal/simpleUpload/upload.php';
+    //}
     /**** COMMENT OUT ABOVE, UNCOMMENT BELOW TO TEST YOUR REMOTE SERVER ***/
-    //var uploadUrl =
-        //'https://nknportal-dev.nkn.uidaho.edu/portal/simpleUpload/upload.php';
+    var uploadUrl =
+        'https://nknportal-dev.nkn.uidaho.edu/portal/simpleUpload/upload.php';
 
     var attachBaseRoute;
     if (hostname !== 'localhost:4000') {


### PR DESCRIPTION
As before, run in production mode and then visit https://nknportal-dev.nkn.uidaho.edu/portal/simpleUpload/uploads/ to see the newly-created directory with `metadata.xml` when you publish.

To run in production mode, execute the following in a terminal

```
FLASKCONFIG='production'
export FLASKCONFIG
```