### PR TITLE
Fixed the styling that broke in Chrome.

### DIFF
--- a/frontend/css/metadata.css
+++ b/frontend/css/metadata.css
@@ -321,7 +321,7 @@ a.dropdown-toggle, a.btn {
 #status-buttons a               {
     display:inline-block;
     font-size: 14px;
-    margin-right:10px;
+    margin-right:15px;
     text-align:center;
     text-transform:uppercase;
 }


### PR DESCRIPTION
Fixed gap between arrows in Chrome. For some reason, the new update of Chrome broke the spacing, and there was a gap between parts of the button that should not have spaces. 